### PR TITLE
Remove slf4j logger and use org.sonar.api.utils.log.Logger and org.sonar.api.utils.log.Loggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.8</version>
@@ -98,12 +92,6 @@
 			<groupId>com.intellij</groupId>
 			<artifactId>annotations</artifactId>
 			<version>12.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.10</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/fr/techad/sonar/GerritConfiguration.java
+++ b/src/main/java/fr/techad/sonar/GerritConfiguration.java
@@ -3,15 +3,15 @@ package fr.techad.sonar;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.BatchComponent;
 import org.sonar.api.batch.InstantiationStrategy;
 import org.sonar.api.config.Settings;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class GerritConfiguration implements BatchComponent {
-    private static final Logger LOG = LoggerFactory.getLogger(GerritConfiguration.class);
+    private static final Logger LOG = Loggers.get(GerritConfiguration.class);
 
     private boolean enabled;
     private boolean valid;

--- a/src/main/java/fr/techad/sonar/GerritInitializer.java
+++ b/src/main/java/fr/techad/sonar/GerritInitializer.java
@@ -1,15 +1,14 @@
 package fr.techad.sonar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.Initializer;
 import org.sonar.api.resources.Project;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
-import fr.techad.sonar.GerritConfiguration;
 import fr.techad.sonar.gerrit.GerritFacade;
 
 public class GerritInitializer extends Initializer {
-    private static final Logger LOG = LoggerFactory.getLogger(GerritInitializer.class);
+    private static final Logger LOG = Loggers.get(GerritInitializer.class);
     private final GerritConfiguration gerritConfiguration;
     private GerritFacade gerritFacade;
 

--- a/src/main/java/fr/techad/sonar/GerritPostJob.java
+++ b/src/main/java/fr/techad/sonar/GerritPostJob.java
@@ -1,13 +1,13 @@
 package fr.techad.sonar;
 
-import java.util.*;
-
-import fr.techad.sonar.gerrit.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.DecoratorBarriers;
 import org.sonar.api.batch.DependsUpon;
 import org.sonar.api.batch.PostJob;
@@ -21,10 +21,18 @@ import org.sonar.api.measures.Measure;
 import org.sonar.api.measures.MeasuresFilters;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.resources.Project;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import fr.techad.sonar.gerrit.GerritFacade;
+import fr.techad.sonar.gerrit.ReviewFileComment;
+import fr.techad.sonar.gerrit.ReviewInput;
+import fr.techad.sonar.gerrit.ReviewLineComment;
+import fr.techad.sonar.gerrit.ReviewUtils;
 
 @DependsUpon(DecoratorBarriers.ISSUES_TRACKED)
 public class GerritPostJob implements PostJob {
-    private static final Logger LOG = LoggerFactory.getLogger(GerritPostJob.class);
+    private static final Logger LOG = Loggers.get(GerritPostJob.class);
     private static final String PROP_START = "${";
     private static final int PROP_START_LENGTH = PROP_START.length();
     private static final char PROP_END = '}';

--- a/src/main/java/fr/techad/sonar/gerrit/GerritConnector.java
+++ b/src/main/java/fr/techad/sonar/gerrit/GerritConnector.java
@@ -25,16 +25,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.BatchComponent;
 import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import fr.techad.sonar.GerritConfiguration;
 
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class GerritConnector implements BatchComponent {
-    private static final Logger LOG = LoggerFactory.getLogger(GerritConnector.class);
+    private static final Logger LOG = Loggers.get(GerritConnector.class);
     private static final String BASIC_AUTH_SCHEME = "BASIC";
     private static final String DIGEST_AUTH_SCHEME = "DIGEST";
     private static final String URI_AUTH_PREFIX = "/a";

--- a/src/main/java/fr/techad/sonar/gerrit/GerritFacade.java
+++ b/src/main/java/fr/techad/sonar/gerrit/GerritFacade.java
@@ -1,26 +1,26 @@
 package fr.techad.sonar.gerrit;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import fr.techad.sonar.GerritPluginException;
-
-import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sonar.api.BatchComponent;
-import org.sonar.api.batch.InstantiationStrategy;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.sonar.api.BatchComponent;
+import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fr.techad.sonar.GerritPluginException;
+
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class GerritFacade implements BatchComponent {
-    private static final Logger LOG = LoggerFactory.getLogger(GerritFacade.class);
+    private static final Logger LOG = Loggers.get(GerritFacade.class);
     private static final String RESPONSE_PREFIX = ")]}'";
     private static final String COMMIT_MSG = "/COMMIT_MSG";
     private static final String MAVEN_ENTRY_REGEX = ".*src/";

--- a/src/main/java/fr/techad/sonar/gerrit/ReviewFileComment.java
+++ b/src/main/java/fr/techad/sonar/gerrit/ReviewFileComment.java
@@ -1,15 +1,15 @@
 package fr.techad.sonar.gerrit;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 /**
  * Gerrit comment used with request for review input. Used with JSON marshaller
  * only.
  */
 public class ReviewFileComment {
-    private static final Logger LOG = LoggerFactory.getLogger(ReviewFileComment.class);
+    private static final Logger LOG = Loggers.get(ReviewFileComment.class);
 
     private String message;
 

--- a/src/main/java/fr/techad/sonar/gerrit/ReviewLineComment.java
+++ b/src/main/java/fr/techad/sonar/gerrit/ReviewLineComment.java
@@ -1,11 +1,11 @@
 package fr.techad.sonar.gerrit;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class ReviewLineComment extends ReviewFileComment {
-    private static final Logger LOG = LoggerFactory.getLogger(ReviewLineComment.class);
+    private static final Logger LOG = Loggers.get(ReviewLineComment.class);
     private Integer line = 0;
 
     public Integer getLine() {

--- a/src/main/java/fr/techad/sonar/gerrit/ReviewUtils.java
+++ b/src/main/java/fr/techad/sonar/gerrit/ReviewUtils.java
@@ -4,12 +4,12 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.rule.Severity;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class ReviewUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(ReviewUtils.class);
+    private static final Logger LOG = Loggers.get(ReviewUtils.class);
     private static final String LOG_MESSAGE = "[GERRIT PLUGIN] Got review level {}, level is now {}";
     private static final String UNKNOWN = "UNKNOWN";
     private static final int INFO_VALUE = 0;


### PR DESCRIPTION
Remove slf4j dependency to be compatible with Sonar Qube 5.2, use Logger and Loggers sonar qube class instead of slf4j logger.