### PR TITLE
Send message to gerrit at the very begining of the SQ analysis

### DIFF
--- a/src/main/java/fr/techad/sonar/GerritPlugin.java
+++ b/src/main/java/fr/techad/sonar/GerritPlugin.java
@@ -100,7 +100,7 @@ public final class GerritPlugin extends SonarPlugin {
                 .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
 
         return Arrays.asList(GerritConfiguration.class, GerritConnector.class, GerritFacade.class,
-                GerritInitializer.class, GerritPostJob.class, enabled, scheme, host, port,
+                GerritInitializer.class, GerritProjectBuilder.class, GerritPostJob.class, enabled, scheme, host, port,
                 username, password, authScheme, basePath, label, message, forceBranch, newIssuesOnly, threshold,
                 voteNoIssue, voteIssueBelowThreshold, voteIssueAboveThreshold);
     }

--- a/src/main/java/fr/techad/sonar/GerritProjectBuilder.java
+++ b/src/main/java/fr/techad/sonar/GerritProjectBuilder.java
@@ -1,0 +1,37 @@
+package fr.techad.sonar;
+
+import org.sonar.api.batch.bootstrap.ProjectBuilder;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import fr.techad.sonar.gerrit.GerritFacade;
+import fr.techad.sonar.gerrit.ReviewInput;
+
+public class GerritProjectBuilder extends ProjectBuilder {
+	private static final Logger LOG = Loggers.get(GerritProjectBuilder.class);
+	private final GerritConfiguration gerritConfiguration;
+	private final GerritFacade gerritFacade;
+
+	public GerritProjectBuilder(GerritConfiguration gerritConfiguration, GerritFacade gerritFacade) {
+		LOG.debug("[GERRIT PLUGIN] Instanciating GerritProjectBuilder");
+		this.gerritConfiguration = gerritConfiguration;
+		this.gerritFacade = gerritFacade;
+	}
+
+	@Override
+	public void build(Context context) {
+		if (!gerritConfiguration.isEnabled()) {
+			return;
+		}
+
+		ReviewInput ri = new ReviewInput();
+		ri.setValueAndLabel(0, gerritConfiguration.getLabel());
+		ri.setMessage("Sonar review in progress …");
+		
+		try {
+			gerritFacade.setReview(ri);
+		} catch (GerritPluginException e) {
+			LOG.error("[GERRIT PLUGIN] Sending initial status failed", e);
+		}
+	}
+}


### PR DESCRIPTION
Send a message to gerrit when the SQ analysis starts.
Also set the voting label to 0 (neutral).