### PR TITLE
Do not comment file if marked as DELETED

### DIFF
--- a/src/main/java/fr/techad/sonar/gerrit/GerritRestFacade.java
+++ b/src/main/java/fr/techad/sonar/gerrit/GerritRestFacade.java
@@ -45,6 +45,14 @@ public class GerritRestFacade extends GerritFacade {
 					if (COMMIT_MSG.equals(fileName)) {
 						continue;
 					}
+					
+					if (fileList.getValue().getAsJsonObject().has("status")) {
+						if (fileList.getValue().getAsJsonObject().get("status").getAsCharacter() == 'D') {
+							LOG.debug("[GERRIT PLUGIN] File is marked as deleted, won't comment.");
+							continue;
+						}
+					}
+					
 					gerritFileList.add(fileName);
 				}
 			} catch (IOException e) {

--- a/src/main/java/fr/techad/sonar/gerrit/GerritSshFacade.java
+++ b/src/main/java/fr/techad/sonar/gerrit/GerritSshFacade.java
@@ -44,6 +44,14 @@ public class GerritSshFacade extends GerritFacade {
 					if (COMMIT_MSG.equals(fileName)) {
 						continue;
 					}
+					
+					if (jsonElement.getAsJsonObject().has("type")) {
+						if (jsonElement.getAsJsonObject().get("type").getAsString().equals("DELETED")) {
+							LOG.debug("[GERRIT PLUGIN] File is marked as deleted, won't comment.");
+							continue;
+						}
+					}
+					
 					gerritFileList.add(fileName);
 				}
 			} catch (IOException e) {


### PR DESCRIPTION
Not an user configurable option (until explicitly requested) : deleted files are not meant to be analyzed. Waste of time for everyone.