### PR TITLE
Allow to bypass SSH StrictHostKeyChecking

### DIFF
--- a/src/main/java/fr/techad/sonar/GerritConfiguration.java
+++ b/src/main/java/fr/techad/sonar/GerritConfiguration.java
@@ -18,6 +18,7 @@ public class GerritConfiguration {
     private boolean valid;
     private boolean anonymous;
     private boolean commentNewIssuesOnly;
+    private boolean strictHostkey;
 
     private String host;
 
@@ -48,6 +49,7 @@ public class GerritConfiguration {
 
         this.enable(settings.getBoolean(PropertyKey.GERRIT_ENABLED));
         this.commentNewIssuesOnly(settings.getBoolean(PropertyKey.GERRIT_COMMENT_NEW_ISSUES_ONLY));
+        this.strictlyCheckHostkey(settings.getBoolean(PropertyKey.GERRIT_STRICT_HOSTKEY));
 
         this.setScheme(settings.getString(PropertyKey.GERRIT_SCHEME));
         this.setHost(settings.getString(PropertyKey.GERRIT_HOST));
@@ -107,6 +109,15 @@ public class GerritConfiguration {
 
     public boolean shouldCommentNewIssuesOnly() {
         return commentNewIssuesOnly;
+    }
+
+    public GerritConfiguration strictlyCheckHostkey(boolean strictHostkey) {
+        this.strictHostkey = strictHostkey;
+        return this;
+    }
+
+    public boolean shouldStrictlyCheckHostKey() {
+        return strictHostkey;
     }
 
     @NotNull

--- a/src/main/java/fr/techad/sonar/GerritConstants.java
+++ b/src/main/java/fr/techad/sonar/GerritConstants.java
@@ -13,6 +13,7 @@ public final class GerritConstants {
     public static final String AUTH_BASIC = "basic";
     public static final String AUTH_DIGEST = "digest";
     public static final String GERRIT_COMMENT_NEW_ISSUES_ONLY = "false";
+    public static final String GERRIT_STRICT_HOSTKEY_DEFAULT = "true";
     public static final String GERRIT_VOTE_NO_ISSUE_DEFAULT = "+1";
     public static final String GERRIT_VOTE_ISSUE_BELOW_THRESHOLD_DEFAULT = "+1";
     public static final String GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD_DEFAULT = "-1";

--- a/src/main/java/fr/techad/sonar/GerritPlugin.java
+++ b/src/main/java/fr/techad/sonar/GerritPlugin.java
@@ -15,101 +15,106 @@ import java.util.Arrays;
 
 public final class GerritPlugin implements Plugin {
 
-	private int serverBaseIndex;
-	private int reviewBaseIndex;
+    private int serverBaseIndex;
+    private int reviewBaseIndex;
 
-	@Override
-	public void define(Context context) {
-		PropertyDefinition enabled = PropertyDefinition.builder(PropertyKey.GERRIT_ENABLED)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.BOOLEAN).defaultValue(GerritConstants.GERRIT_ENABLED_DEFAULT)
-				.onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(serverBaseIndex++).build();
+    @Override
+    public void define(Context context) {
+        PropertyDefinition enabled = PropertyDefinition.builder(PropertyKey.GERRIT_ENABLED)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.BOOLEAN).defaultValue(GerritConstants.GERRIT_ENABLED_DEFAULT)
+                .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(serverBaseIndex++).build();
 
-		PropertyDefinition scheme = PropertyDefinition.builder(PropertyKey.GERRIT_SCHEME)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.SINGLE_SELECT_LIST)
-				.options(GerritConstants.SCHEME_HTTP, GerritConstants.SCHEME_HTTPS, GerritConstants.SCHEME_SSH)
-				.defaultValue(GerritConstants.SCHEME_HTTP).index(serverBaseIndex++).build();
+        PropertyDefinition scheme = PropertyDefinition.builder(PropertyKey.GERRIT_SCHEME)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.SINGLE_SELECT_LIST)
+                .options(GerritConstants.SCHEME_HTTP, GerritConstants.SCHEME_HTTPS, GerritConstants.SCHEME_SSH)
+                .defaultValue(GerritConstants.SCHEME_HTTP).index(serverBaseIndex++).build();
 
-		PropertyDefinition host = PropertyDefinition.builder(PropertyKey.GERRIT_HOST)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.index(serverBaseIndex++).build();
+        PropertyDefinition host = PropertyDefinition.builder(PropertyKey.GERRIT_HOST)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .index(serverBaseIndex++).build();
 
-		PropertyDefinition port = PropertyDefinition.builder(PropertyKey.GERRIT_PORT)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.INTEGER).defaultValue("80").index(serverBaseIndex++).build();
+        PropertyDefinition port = PropertyDefinition.builder(PropertyKey.GERRIT_PORT)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.INTEGER).defaultValue("80").index(serverBaseIndex++).build();
 
-		PropertyDefinition username = PropertyDefinition.builder(PropertyKey.GERRIT_USERNAME)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.index(serverBaseIndex++).build();
+        PropertyDefinition username = PropertyDefinition.builder(PropertyKey.GERRIT_USERNAME)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .index(serverBaseIndex++).build();
 
-		PropertyDefinition password = PropertyDefinition.builder(PropertyKey.GERRIT_PASSWORD)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.PASSWORD).index(serverBaseIndex++).build();
+        PropertyDefinition password = PropertyDefinition.builder(PropertyKey.GERRIT_PASSWORD)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.PASSWORD).index(serverBaseIndex++).build();
 
-		PropertyDefinition sshKeyPath = PropertyDefinition.builder(PropertyKey.GERRIT_SSH_KEY_PATH)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.STRING).index(serverBaseIndex++).build();
+        PropertyDefinition sshKeyPath = PropertyDefinition.builder(PropertyKey.GERRIT_SSH_KEY_PATH)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.STRING).index(serverBaseIndex++).build();
 
-		PropertyDefinition authScheme = PropertyDefinition.builder(PropertyKey.GERRIT_HTTP_AUTH_SCHEME)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.type(PropertyType.SINGLE_SELECT_LIST).options(GerritConstants.AUTH_BASIC, GerritConstants.AUTH_DIGEST)
-				.defaultValue(GerritConstants.AUTH_DIGEST).index(serverBaseIndex++).build();
+        PropertyDefinition strictHostkey = PropertyDefinition.builder(PropertyKey.GERRIT_STRICT_HOSTKEY)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.BOOLEAN).defaultValue(GerritConstants.GERRIT_STRICT_HOSTKEY_DEFAULT)
+                .index(serverBaseIndex++).build();
 
-		PropertyDefinition basePath = PropertyDefinition.builder(PropertyKey.GERRIT_BASE_PATH)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
-				.defaultValue("/").index(serverBaseIndex++).build();
+        PropertyDefinition authScheme = PropertyDefinition.builder(PropertyKey.GERRIT_HTTP_AUTH_SCHEME)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .type(PropertyType.SINGLE_SELECT_LIST).options(GerritConstants.AUTH_BASIC, GerritConstants.AUTH_DIGEST)
+                .defaultValue(GerritConstants.AUTH_DIGEST).index(serverBaseIndex++).build();
 
-		PropertyDefinition label = PropertyDefinition.builder(PropertyKey.GERRIT_LABEL)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.defaultValue("Code-Review").index(reviewBaseIndex++).build();
+        PropertyDefinition basePath = PropertyDefinition.builder(PropertyKey.GERRIT_BASE_PATH)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_SERVER)
+                .defaultValue("/").index(serverBaseIndex++).build();
 
-		PropertyDefinition message = PropertyDefinition.builder(PropertyKey.GERRIT_MESSAGE)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.defaultValue("Sonar review at ${sonar.host.url}").index(reviewBaseIndex++).build();
+        PropertyDefinition label = PropertyDefinition.builder(PropertyKey.GERRIT_LABEL)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .defaultValue("Code-Review").index(reviewBaseIndex++).build();
 
-		PropertyDefinition newIssuesOnly = PropertyDefinition.builder(PropertyKey.GERRIT_COMMENT_NEW_ISSUES_ONLY)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.type(PropertyType.BOOLEAN).defaultValue(GerritConstants.GERRIT_COMMENT_NEW_ISSUES_ONLY)
-				.onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
+        PropertyDefinition message = PropertyDefinition.builder(PropertyKey.GERRIT_MESSAGE)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .defaultValue("Sonar review at ${sonar.host.url}").index(reviewBaseIndex++).build();
 
-		PropertyDefinition threshold = PropertyDefinition.builder(PropertyKey.GERRIT_THRESHOLD)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.type(PropertyType.SINGLE_SELECT_LIST)
-				.options(Severity.INFO.toString(), Severity.MINOR.toString(), Severity.MAJOR.toString(),
-						Severity.CRITICAL.toString(), Severity.BLOCKER.toString())
-				.defaultValue(Severity.INFO.toString()).onQualifiers(Arrays.asList(Qualifiers.PROJECT))
-				.index(reviewBaseIndex++).build();
+        PropertyDefinition newIssuesOnly = PropertyDefinition.builder(PropertyKey.GERRIT_COMMENT_NEW_ISSUES_ONLY)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .type(PropertyType.BOOLEAN).defaultValue(GerritConstants.GERRIT_COMMENT_NEW_ISSUES_ONLY)
+                .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
 
-		PropertyDefinition voteNoIssue = PropertyDefinition.builder(PropertyKey.GERRIT_VOTE_NO_ISSUE)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.type(PropertyType.SINGLE_SELECT_LIST).options("+1", "+2")
-				.defaultValue(GerritConstants.GERRIT_VOTE_NO_ISSUE_DEFAULT)
-				.onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
+        PropertyDefinition threshold = PropertyDefinition.builder(PropertyKey.GERRIT_THRESHOLD)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .type(PropertyType.SINGLE_SELECT_LIST)
+                .options(Severity.INFO.toString(), Severity.MINOR.toString(), Severity.MAJOR.toString(),
+                        Severity.CRITICAL.toString(), Severity.BLOCKER.toString())
+                .defaultValue(Severity.INFO.toString()).onQualifiers(Arrays.asList(Qualifiers.PROJECT))
+                .index(reviewBaseIndex++).build();
 
-		PropertyDefinition voteIssueBelowThreshold = PropertyDefinition
-				.builder(PropertyKey.GERRIT_VOTE_ISSUE_BELOW_THRESHOLD).category(GerritConstants.GERRIT_CATEGORY)
-				.subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW).type(PropertyType.SINGLE_SELECT_LIST)
-				.options("-2", "-1", "0", "+1", "+2")
-				.defaultValue(GerritConstants.GERRIT_VOTE_ISSUE_BELOW_THRESHOLD_DEFAULT)
-				.onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
+        PropertyDefinition voteNoIssue = PropertyDefinition.builder(PropertyKey.GERRIT_VOTE_NO_ISSUE)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .type(PropertyType.SINGLE_SELECT_LIST).options("+1", "+2")
+                .defaultValue(GerritConstants.GERRIT_VOTE_NO_ISSUE_DEFAULT)
+                .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
 
-		PropertyDefinition voteIssueAboveThreshold = PropertyDefinition
-				.builder(PropertyKey.GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD).category(GerritConstants.GERRIT_CATEGORY)
-				.subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW).type(PropertyType.SINGLE_SELECT_LIST)
-				.options("-2", "-1", "0").defaultValue(GerritConstants.GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD_DEFAULT)
-				.onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
+        PropertyDefinition voteIssueBelowThreshold = PropertyDefinition
+                .builder(PropertyKey.GERRIT_VOTE_ISSUE_BELOW_THRESHOLD).category(GerritConstants.GERRIT_CATEGORY)
+                .subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW).type(PropertyType.SINGLE_SELECT_LIST)
+                .options("-2", "-1", "0", "+1", "+2")
+                .defaultValue(GerritConstants.GERRIT_VOTE_ISSUE_BELOW_THRESHOLD_DEFAULT)
+                .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
 
-		PropertyDefinition issueComment = PropertyDefinition.builder(PropertyKey.GERRIT_ISSUE_COMMENT)
-				.category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
-				.defaultValue(
-						"[${issue.isNew}] New: ${issue.ruleKey} Severity: ${issue.severity}, Message: ${issue.message}")
-				.index(reviewBaseIndex++).build();
+        PropertyDefinition voteIssueAboveThreshold = PropertyDefinition
+                .builder(PropertyKey.GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD).category(GerritConstants.GERRIT_CATEGORY)
+                .subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW).type(PropertyType.SINGLE_SELECT_LIST)
+                .options("-2", "-1", "0").defaultValue(GerritConstants.GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD_DEFAULT)
+                .onQualifiers(Arrays.asList(Qualifiers.PROJECT)).index(reviewBaseIndex++).build();
 
-		context.addExtensions(Arrays.asList(GerritConfiguration.class, GerritConnectorFactory.class,
-				GerritFacadeFactory.class, GerritInitializer.class, GerritProjectBuilder.class, GerritPostJob.class,
-				ReviewUtils.class, MessageUtils.class, enabled, scheme, host, port, username, password, authScheme,
-				basePath, sshKeyPath, label, message, newIssuesOnly, threshold, voteNoIssue, voteIssueBelowThreshold,
-				voteIssueAboveThreshold, issueComment));
-	}
+        PropertyDefinition issueComment = PropertyDefinition.builder(PropertyKey.GERRIT_ISSUE_COMMENT)
+                .category(GerritConstants.GERRIT_CATEGORY).subCategory(GerritConstants.GERRIT_SUBCATEGORY_REVIEW)
+                .defaultValue(
+                        "[${issue.isNew}] New: ${issue.ruleKey} Severity: ${issue.severity}, Message: ${issue.message}")
+                .index(reviewBaseIndex++).build();
+
+        context.addExtensions(Arrays.asList(GerritConfiguration.class, GerritConnectorFactory.class,
+                GerritFacadeFactory.class, GerritInitializer.class, GerritProjectBuilder.class, GerritPostJob.class,
+                ReviewUtils.class, MessageUtils.class, enabled, scheme, host, port, username, password, authScheme,
+                basePath, sshKeyPath, strictHostkey, label, message, newIssuesOnly, threshold, voteNoIssue,
+                voteIssueBelowThreshold, voteIssueAboveThreshold, issueComment));
+    }
 }

--- a/src/main/java/fr/techad/sonar/PropertyKey.java
+++ b/src/main/java/fr/techad/sonar/PropertyKey.java
@@ -23,6 +23,7 @@ public final class PropertyKey {
     public static final String GERRIT_VOTE_ISSUE_BELOW_THRESHOLD = "GERRIT_VOTE_ISSUE_BELOW_THRESHOLD";
     public static final String GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD = "GERRIT_VOTE_ISSUE_ABOVE_THRESHOLD";
     public static final String GERRIT_ISSUE_COMMENT = "GERRIT_ISSUE_COMMENT";
+    public static final String GERRIT_STRICT_HOSTKEY = "GERRIT_STRICT_HOSTKEY";
 
     private PropertyKey() {
     }

--- a/src/main/java/fr/techad/sonar/gerrit/network/ssh/GerritSshConnector.java
+++ b/src/main/java/fr/techad/sonar/gerrit/network/ssh/GerritSshConnector.java
@@ -2,11 +2,15 @@ package fr.techad.sonar.gerrit.network.ssh;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Paths;
 
 import fi.jpalomaki.ssh.Result;
 import fi.jpalomaki.ssh.SshClient;
 import fi.jpalomaki.ssh.UserAtHost;
 import fi.jpalomaki.ssh.jsch.JschSshClient;
+import fi.jpalomaki.ssh.jsch.JschSshClient.Options;
 
 import org.jetbrains.annotations.NotNull;
 import org.sonar.api.utils.log.Logger;
@@ -19,6 +23,9 @@ public class GerritSshConnector implements GerritConnector {
     private static final Logger LOG = Loggers.get(GerritSshConnector.class);
     private static final String CMD_LIST_FILES = "gerrit query --format=JSON --files --current-patch-set status:open change:%s limit:1";
     private static final String CMD_SET_REVIEW = "gerrit review %s -j";
+    private static final String SSH_KNWON_HOSTS = "~/.ssh/known_hosts";
+    private static final String SSH_STRICT_NO = "StrictHostKeyChecking=no";
+
     private final GerritConfiguration gerritConfiguration;
     private final UserAtHost userAtHost;
 
@@ -32,7 +39,7 @@ public class GerritSshConnector implements GerritConnector {
     @NotNull
     @Override
     public String listFiles() throws IOException {
-        SshClient sshClient = new JschSshClient(gerritConfiguration.getSshKeyPath(), gerritConfiguration.getPassword());
+        SshClient sshClient = getSshClient();
 
         LOG.debug("[GERRIT PLUGIN] Execute command SSH {}",
                 String.format(CMD_LIST_FILES, gerritConfiguration.getChangeId()));
@@ -49,8 +56,7 @@ public class GerritSshConnector implements GerritConnector {
         LOG.info("[GERRIT PLUGIN] Setting review {}", reviewInputAsJson);
 
         ByteBuffer stdin = ByteBuffer.wrap(reviewInputAsJson.getBytes("UTF-8"));
-        SshClient sshClient = new JschSshClient(gerritConfiguration.getSshKeyPath(), gerritConfiguration.getPassword());
-
+        SshClient sshClient = getSshClient();
         LOG.debug("[GERRIT PLUGIN] Execute command SSH {}",
                 String.format(CMD_SET_REVIEW, gerritConfiguration.getRevisionId()));
 
@@ -58,5 +64,33 @@ public class GerritSshConnector implements GerritConnector {
                 stdin, userAtHost);
 
         return cmdResult.stdoutAsText();
+    }
+
+    private SshClient getSshClient() {
+        SshClient sc = null;
+
+        if (gerritConfiguration.shouldStrictlyCheckHostKey()) {
+            LOG.debug("[GERRIT PLUGIN] SSH will check host key.");
+            sc = new JschSshClient(gerritConfiguration.getSshKeyPath(), gerritConfiguration.getPassword());
+        } else {
+            LOG.debug("[GERRIT PLUGIN] SSH will not check host key.");
+            Boolean knownHostsExists = Files.exists(Paths.get(SSH_KNWON_HOSTS), LinkOption.NOFOLLOW_LINKS);
+            
+            if (!knownHostsExists) {
+                LOG.debug("[GERRIT PLUGIN] {} does not exist. Creating.", SSH_KNWON_HOSTS);
+                // known_hosts DOES NOT exists => create it
+                try {
+                    Files.createFile(Paths.get(SSH_KNWON_HOSTS));
+                } catch (IOException e) {
+                    LOG.warn("[GERRIT PLUGIN] Could not create known_hosts", e);
+                }
+                LOG.debug("[GERRIT PLUGIN] {} created.", SSH_KNWON_HOSTS);
+            }
+            
+            sc = new JschSshClient(gerritConfiguration.getSshKeyPath(), gerritConfiguration.getPassword(),
+                    SSH_KNWON_HOSTS, new Options("5s", "0s", "1M", "1M", SSH_STRICT_NO, false));
+        }
+
+        return sc;
     }
 }

--- a/src/main/resources/org/sonar/l10n/gerrit.properties
+++ b/src/main/resources/org/sonar/l10n/gerrit.properties
@@ -44,3 +44,5 @@ property.GERRIT_FORCE_BRANCH.name=Force branch
 property.GERRIT_FORCE_BRANCH.description=Set to true to force branch creation in SQ and override its name with Gerrit's branch name.
 property.GERRIT_COMMENT_NEW_ISSUES_ONLY.name=Comment new issues only
 property.GERRIT_COMMENT_NEW_ISSUES_ONLY.description=Sonar comment only newly created issues. Existing issues will not be reported.
+property.GERRIT_STRICT_HOSTKEY.name=SSH StrictHostKeyChecking
+property.GERRIT_STRICT_HOSTKEY.description=Enable or disable StrictHostKeyChecking when connection scheme is ssh.

--- a/src/main/resources/org/sonar/l10n/gerrit_fr.properties
+++ b/src/main/resources/org/sonar/l10n/gerrit_fr.properties
@@ -44,3 +44,5 @@ property.GERRIT_FORCE_BRANCH.name=Forcer la branche
 property.GERRIT_FORCE_BRANCH.description=Mettre \u00e0 true pour surcharger et cr\u00e9er automatiquement une nouvelle branche dans SonarQube avec le nom de la branche Gerrit.
 property.GERRIT_COMMENT_NEW_ISSUES_ONLY.name=Commenter seulement les nouveaux d\u00e9fauts
 property.GERRIT_COMMENT_NEW_ISSUES_ONLY.description=Sonar ne commentera que les nouveaux d\u00e9fauts. Les d\u00e9fauts existants ne seront pas remont\u00e9s.
+property.GERRIT_STRICT_HOSTKEY.name=SSH StrictHostKeyChecking
+property.GERRIT_STRICT_HOSTKEY.description=Active ou d\u00e9sactive StrictHostKeyChecking lorsque le sch\u00e9ma d'URI est ssh.


### PR DESCRIPTION
For issue #42 
Create a new boolean settings in SonarQube to disable StrictHostKeyChecking (enable by default)
If StrictHostKeyChecking is disable, it will however create a known_hosts file if it does not already exist.

Change-Id: I5e21b31b65fbee2136524196650fde3461eaa5b9